### PR TITLE
Add BQ and SCC Permissions

### DIFF
--- a/security_assessment_role.yaml
+++ b/security_assessment_role.yaml
@@ -89,6 +89,9 @@ includedPermissions:
 - securitycenter.subscription.get
 - securitycenter.websecurityscannersettings.calculate
 - securitycenter.websecurityscannersettings.get
+- securitycenter.userinterfacemetadata.get
+
+#  Service Usage
 - serviceusage.quotas.get
 - serviceusage.services.get
 - serviceusage.services.list

--- a/security_assessment_role.yaml
+++ b/security_assessment_role.yaml
@@ -844,6 +844,11 @@ includedPermissions:
 
 # Cloud Asset Inventory
 
+- cloudasset.assets.listAccessPolicy
+- cloudasset.assets.listIamPolicy
+- cloudasset.assets.listOSInventories
+- cloudasset.assets.listOrgPolicy
+- cloudasset.assets.listResource
 - cloudasset.assets.analyzeIamPolicy
 - cloudasset.assets.exportAccessLevel
 - cloudasset.assets.exportAccessPolicy

--- a/security_assessment_role.yaml
+++ b/security_assessment_role.yaml
@@ -223,6 +223,9 @@ includedPermissions:
 - bigquery.tables.get
 - bigquery.tables.getIamPolicy
 - bigquery.datasets.get
+- bigquery.transfers.get
+
+# Big Table
 - bigtable.appProfiles.get
 - bigtable.appProfiles.list
 - bigtable.backups.getIamPolicy


### PR DESCRIPTION
This PR adds the following permissions to the Assessment IAM Role

1. securitycenter.userinterfacemetadata.get -  Used to read SCC metadata
2. bigquery.transfers.get - Used to read BQ Transfer and Scheduled Query Metadata